### PR TITLE
HIP-23: Istanbul DeFi Application Patterns (topic-split docs)

### DIFF
--- a/HIP/HIP-table.md
+++ b/HIP/HIP-table.md
@@ -11,7 +11,8 @@ Status mark:
 
 | |HIP|Name|Document|Discuss|
 |---|:---:|---|---:|---:|
-|❔|22|Upgrade HACD Inscriptions|[github ➚](/blob/main/HIP/diamond/Upgrade_HACD_Inscriptions.md)| | 
+|❔|23|Istanbul DeFi Application Patterns|[github ➚](/blob/main/HIP/protocol/hip-23/spec.md)| |
+|❔|22|Upgrade HACD Inscriptions|[github ➚](/blob/main/HIP/diamond/Upgrade_HACD_Inscriptions.md)| |
 |❔|21|Hacash Virtual Machine|[hvm.pdf ➚](https://hacash.com/hvm.pdf)|[X ➚](https://x.com/YouKenTrust/status/1921959644291031440) | 
 |❔|20|Issuance of Assets on Mainnet| |[hacashtalk ➚](https://hacashtalk.com/t/proposal-for-the-issuance-of-external-assets-on-the-hacash-mainnet-draft/338) | 
 |❔|18|HACD Minimum Bidding Fee|[github ➚](https://github.com/hacash/fullnode/issues/5#issuecomment-2626283210)|[github ➚](https://github.com/hacash/fullnode/issues/5)|

--- a/HIP/protocol/hip-23/README.md
+++ b/HIP/protocol/hip-23/README.md
@@ -1,0 +1,21 @@
+# HIP-23: Istanbul DeFi Application Patterns
+
+**Status:** v1.1 Ready  
+**Type:** Application / integration standard — **no consensus fork**  
+**Activation:** Istanbul @ mainnet height `765432` (`ONLINE_OPEN_HEIGHT`)  
+**Integration tests:** [hip23-integration](https://github.com/Moskyera/hip23-integration)
+
+Each file below covers a single topic.
+
+| Document | Topic |
+|----------|-------|
+| [spec.md](spec.md) | Normative patterns P1–P5, MUST/SHOULD rules |
+| [templates.md](templates.md) | Copy-paste JSON transaction templates |
+| [threat_model.md](threat_model.md) | Threat analysis |
+| [invariants.md](invariants.md) | Pattern invariants |
+| [requirements_traceability.md](requirements_traceability.md) | MUST requirement trace matrix |
+| [wallet_checklist.md](wallet_checklist.md) | Pre-sign wallet validation |
+| [indexer_dictionary.md](indexer_dictionary.md) | Normalized error / event dictionary |
+| [audit_scope.md](audit_scope.md) | Audit scope boundary |
+| [audit_findings.md](audit_findings.md) | Findings register |
+| [external_audit_brief.md](external_audit_brief.md) | External auditor brief |

--- a/HIP/protocol/hip-23/audit_findings.md
+++ b/HIP/protocol/hip-23/audit_findings.md
@@ -1,0 +1,190 @@
+# HIP-23 Audit Findings Register
+
+Version: 1.0  
+Date: 2026-06-22  
+Method: internal audit per `HIP23_audit_scope.md`
+
+---
+
+## Summary
+
+| Severity | Open | Fixed | Accepted |
+|----------|------|-------|----------|
+| High | 0 | 2 | 1 |
+| Medium | 0 | 3 | 2 |
+| Low | 0 | 3 | 0 |
+| Informational | 2 | 0 | 3 |
+
+No critical consensus issues (expected — HIP-23 is application-layer).
+
+---
+
+## Findings
+
+### F-001 — TEX signatures replayable across txs
+
+| Field | Value |
+|-------|-------|
+| Severity | **Accepted / High (integrator)** |
+| Pattern | P1, P4 |
+| Status | Documented + tested |
+
+**Description:** `TexCellAct` signs `addr + cells` only. The same valid bundle may appear in multiple composed Type3 txs if counterparties co-sign without pinning the full tx.
+
+**Proof:** `hip23_tex_replay_same_bundle_different_main_succeeds` (wire replay via `clone_tex_wire`)
+
+**Remediation:** Wallet checklist §co-signing; `HIP23_threat_model.md` T-P1-2. Not a protocol bug.
+
+---
+
+### F-002 — P3 floor-before-debit bypasses protection
+
+| Field | Value |
+|-------|-------|
+| Severity | **High** |
+| Pattern | P3 |
+| Status | **Fixed** (documented + tested) |
+
+**Description:** `BalanceFloor` reads in-tx state at guard index. Floor listed before debit checks pre-debit balance.
+
+**Proof:** `hip23_p3_floor_before_transfer_checks_pre_debit_state`
+
+**Remediation:** `HIP23_wallet_checklist.md` P3 ordering MUST; `spec.md` §6.4.
+
+---
+
+### F-003 — P2 debit-before-guard confuses simulators
+
+| Field | Value |
+|-------|-------|
+| Severity | **Medium** |
+| Pattern | P2 |
+| Status | **Fixed** (documented + tested) |
+
+**Description:** Wrong ordering still fails whole tx on-chain, but step simulators may show debit before revert.
+
+**Proof:** `hip23_p2_transfer_before_guard_still_reverts_outside_window`, `hip23_chain_failed_tx_does_not_commit`
+
+**Remediation:** `spec.md` §5.4; wallet atomic simulation requirement.
+
+---
+
+### F-004 — P4 AssetCreate + TEX same tx rejected
+
+| Field | Value |
+|-------|-------|
+| Severity | **Medium** |
+| Pattern | P4 |
+| Status | **Fixed** (by design) |
+
+**Description:** `AssetCreate` is `TOP_ONLY`; combined tx fails topology check.
+
+**Proof:** `hip23_p4_asset_create_with_tex_same_tx_rejected`
+
+**Remediation:** Two-tx flow documented in §7.
+
+---
+
+### F-005 — P5 condition fault vs revert
+
+| Field | Value |
+|-------|-------|
+| Severity | **Medium** |
+| Pattern | P5 |
+| Status | **Fixed** (documented) |
+
+**Description:** Invalid height range faults entire `AstIf`; outside window reverts to else. Wallets conflating these mis-label tx outcome.
+
+**Proof:** `hip23_p5_ast_if_condition_fault_aborts_whole_node`, `hip23_p5_ast_else_branch_executes_transfer`
+
+**Remediation:** `HIP23_indexer_dictionary.md` `cond_outcome` + `ast_branch`.
+
+---
+
+### F-006 — fast_sync test harness skips production checks
+
+| Field | Value |
+|-------|-------|
+| Severity | **Medium (process)** |
+| Pattern | All |
+| Status | **Mitigated** |
+
+**Description:** ~85% of HIP-23 tests use `fast_sync=true`, skipping signature and duplicate-tx validation.
+
+**Proof:** `[hip23-integration/tests/common/hip23.rs](https://github.com/Moskyera/hip23-integration)`; production suites added.
+
+**Remediation:** `hip23_production_path.rs`, `hip23_audit_strict.rs`, `SECURITY.md` release gate.
+
+---
+
+### F-007 — No stable guard reason-code enum
+
+| Field | Value |
+|-------|-------|
+| Severity | **Low** |
+| Pattern | P2, P3, P5 |
+| Status | **Mitigated** (v1 classifier) |
+
+**Description:** On-chain errors remain strings; no consensus enum in v1.
+
+**Remediation:** `[hip23-integration/tests/common/hip23_errors.rs](https://github.com/Moskyera/hip23-integration)` + `hip23_guard_error_codes.rs` lock stable indexer codes; `HIP23_indexer_dictionary.md` §3.
+
+---
+
+### F-008 — Proptest setup guard drop (fixed)
+
+| Field | Value |
+|-------|-------|
+| Severity | **Low** |
+| Pattern | Test infra |
+| Status | **Fixed** |
+
+**Description:** Repeated `enable_mint_setup()` in proptest cases cleared scoped registry.
+
+**Proof:** `ensure_standard_protocol_setup_for_tests` in `init_setup()`.
+
+---
+
+### F-009 — Main signature tamper rejected in production path
+
+| Field | Value |
+|-------|-------|
+| Severity | Informational |
+| Pattern | All |
+| Status | Verified |
+
+**Proof:** `hip23_production_tampered_main_signature_rejected`, `hip23_audit_strict_main_sig_tamper_rejected`
+
+---
+
+### F-010 — Imbalanced TEX always fails settlement
+
+| Field | Value |
+|-------|-------|
+| Severity | Informational |
+| Pattern | P1 |
+| Status | Verified |
+
+**Proof:** `hip23_p1_tex_imbalanced_*`, proptest `hip23_proptest_imbalanced_tex_always_fails`
+
+---
+
+## Recommendations (informational)
+
+| ID | Recommendation | Priority |
+|----|----------------|----------|
+| R-01 | External third-party audit before mainnet wallet launch | High |
+| R-02 | Add `cargo-fuzz` on TEX parse | Medium (**done**: `fuzz/` + proptest parse property) |
+| R-03 | CI gate on `cargo test hip23_` | Medium (**done**: `.github/workflows/hip23.yml`) |
+| R-04 | Expand proptest to P4/P5 properties | Low (**done**) |
+| R-05 | Cross-implementation test vectors file | Low (**done**: `[hip23-integration/tests/fixtures/hip23_test_vectors.json](https://github.com/Moskyera/hip23-integration)`) |
+
+---
+
+## Sign-off criteria (internal)
+
+- [x] All High findings documented with wallet mitigations
+- [x] Production-path tests pass
+- [x] Chain fork semantics tested
+- [x] Traceability matrix ≥ 90% MUST coverage
+- [ ] External auditor review (pending)

--- a/HIP/protocol/hip-23/audit_scope.md
+++ b/HIP/protocol/hip-23/audit_scope.md
@@ -1,0 +1,109 @@
+# HIP-23 Audit Scope Document
+
+Version: 1.0  
+Date: 2026-06-22  
+Status: Internal / pre-external audit  
+Branch: `hip-23-draft`
+
+---
+
+## 1. Engagement type
+
+Application-layer integration standard audit — **no consensus fork**. Validates that documented patterns P1–P5 match `fullnodedev` behavior and that wallet/indexer guidance is testable.
+
+---
+
+## 2. In scope
+
+| Component | Path | Notes |
+|-----------|------|-------|
+| HIP-23 specification | `spec.md` | Normative MUST/SHOULD |
+| JSON templates | `templates.md` | Structural validity |
+| TEX settlement | `protocol/src/tex/*` | Zero-sum, signatures |
+| Guards | `protocol/src/action/chain.rs` | HeightScope, BalanceFloor, ChainAllow |
+| AST conditionals | `protocol/src/action/ast*` | P5 branch selection |
+| HIP20 AssetCreate | `mint/src/action/asset.rs` | P4 issuance rules |
+| Type3 execute path | `protocol/src/transaction/type3.rs` | Settlement + gas |
+| Chain tx isolation | `chain/src/check.rs` | Fork/merge semantics |
+| HIP-23 test suite | `tests/hip23_*.rs` | All layers |
+| Audit artifacts | `doc/HIP23_*.md`, `SECURITY.md` | This package |
+
+---
+
+## 3. Out of scope
+
+- Consensus / fork activation mechanics
+- HVM contract templates (HIP-23 v2)
+- Cross-chain bridges, oracles, MEV
+- Mempool policy beyond duplicate-tx + signature (node-specific)
+- UI/UX of third-party wallets
+- Economic modeling of `protocol_cost` / fees
+- HIP-25 (separate track)
+
+---
+
+## 4. Assumptions
+
+1. Istanbul active at `ONLINE_OPEN_HEIGHT = 765432`.
+2. Production nodes use `fast_sync = false`.
+3. Integrators read `HIP23_wallet_checklist.md` before co-signing.
+4. Test height baseline: `TEST_HEIGHT = 775432` in harness.
+
+---
+
+## 5. Methodology (aligned with industry practice)
+
+| Phase | Activity | Artifact |
+|-------|----------|----------|
+| 1. Spec review | MUST/SHOULD extraction | `HIP23_requirements_traceability.md` |
+| 2. Threat modeling | STRIDE per pattern | `HIP23_threat_model.md` |
+| 3. Invariant catalog | Formal properties | `HIP23_invariants.md` |
+| 4. Test review | Map tests → requirements | §11 `spec.md` + traceability |
+| 5. Adversarial testing | Negative paths | `hip23_pattern_adversarial.rs` |
+| 6. Production path | Strict-mode smoke | `hip23_production_path.rs`, `hip23_audit_strict.rs` |
+| 7. Property testing | Generative cases | `hip23_proptest.rs` |
+| 8. Chain semantics | Fork/merge atomicity | `hip23_chain_integration.rs` |
+| 9. Replay analysis | TEX signature scope | `hip23_tex_replay.rs` |
+| 10. Findings log | Severity + remediation | `HIP23_audit_findings.md` |
+
+---
+
+## 6. Severity taxonomy
+
+| Level | Definition |
+|-------|------------|
+| Critical | Fund loss or consensus divergence (N/A for HIP-23 — app layer) |
+| High | Integrator fund loss with normal wallet |
+| Medium | Failed tx / UX / accounting error |
+| Low | Documentation or non-exploitable inconsistency |
+| Informational | Hardening recommendation |
+
+---
+
+## 7. Deliverables checklist
+
+- [x] Threat model
+- [x] Invariant catalog
+- [x] Requirements traceability matrix
+- [x] Wallet checklist (v1.1)
+- [x] Indexer dictionary (v1.1)
+- [x] Findings register
+- [x] Chain + replay integration tests
+- [x] Strict-path adversarial mirror
+- [x] `SECURITY.md`
+- [x] External audit brief (`HIP23_external_audit_brief.md`)
+- [x] Stable error classifier (`[hip23-integration/tests/common/hip23_errors.rs](https://github.com/Moskyera/hip23-integration)`)
+- [x] Cross-implementation test vectors (`[hip23-integration/tests/fixtures/hip23_test_vectors.json](https://github.com/Moskyera/hip23-integration)`)
+- [x] `cargo-fuzz` target (`fuzz/fuzz_targets/tex_cell_act_parse.rs`)
+- [ ] External third-party audit engagement (process only)
+
+---
+
+## 8. Test commands for auditors
+
+```bash
+cargo test hip23_ -- --nocapture
+cargo test hip23_audit_ -- --nocapture
+cargo test hip23_chain_ -- --nocapture
+cargo test hip23_tex_replay_ -- --nocapture
+```

--- a/HIP/protocol/hip-23/external_audit_brief.md
+++ b/HIP/protocol/hip-23/external_audit_brief.md
@@ -1,0 +1,77 @@
+# HIP-23 External Audit Brief
+
+Version: 1.0  
+Date: 2026-06-22  
+Branch: `hip-23-draft`  
+Repository: `hacash/fullnodedev` (fork: `Moskyera/fullnodedev`)
+
+---
+
+## 1. Engagement summary
+
+| Item | Value |
+|------|-------|
+| Type | Application-layer integration standard (no consensus fork) |
+| Scope | Patterns P1–P5, wallet/indexer guidance, test harness |
+| Out of scope | Consensus, HVM v2, HIP-25, mempool policy beyond sig/duplicate |
+
+---
+
+## 2. Artifacts for auditors
+
+| Document | Path |
+|----------|------|
+| Normative spec | `spec.md` |
+| JSON templates | `templates.md` |
+| Threat model | `threat_model.md` |
+| Invariants | `invariants.md` |
+| Traceability (26/26 MUST) | `requirements_traceability.md` |
+| Findings register | `audit_findings.md` |
+| Wallet checklist | `wallet_checklist.md` |
+| Indexer dictionary | `indexer_dictionary.md` |
+| Test vectors | `[hip23-integration/tests/fixtures/hip23_test_vectors.json](https://github.com/Moskyera/hip23-integration)` |
+| Error classifier | `[hip23-integration/tests/common/hip23_errors.rs](https://github.com/Moskyera/hip23-integration)` |
+
+---
+
+## 3. Verification commands
+
+```bash
+# Full HIP-23 suite (~85+ named tests + proptest)
+cargo test hip23_ -- --nocapture
+
+# Workspace regression
+cargo test --workspace
+
+# Optional libfuzzer (requires cargo-fuzz)
+cd fuzz && cargo fuzz run tex_cell_act_parse -- -max_total_time=30
+```
+
+---
+
+## 4. Internal sign-off (pre-external)
+
+- [x] MUST requirements traced to tests
+- [x] Production path (`fast_sync=false`) covered
+- [x] Chain fork/merge + duplicate-tx on chain path
+- [x] TEX replay wire + persisted chain demonstration
+- [x] Stable error code classifier (F-007 mitigation)
+- [x] Cross-implementation test vector registry
+- [x] Proptest + fuzz-adjacent parse property
+- [ ] External auditor report (pending engagement)
+
+---
+
+## 5. Residual accepted risks
+
+| Risk | Mitigation |
+|------|------------|
+| TEX replay across txs | Wallet MUST pin full composed tx (`HIP23_wallet_checklist.md`) |
+| Guard errors are strings on-chain | Indexer uses `hip23_errors.rs` classifier |
+| P4 non-atomic two-tx flow | Documented; indexers correlate by serial+issuer |
+
+---
+
+## 6. Contact / process
+
+Report security issues per `SECURITY.md`. HIP-23 changes require `cargo test hip23_` pass before merge.

--- a/HIP/protocol/hip-23/indexer_dictionary.md
+++ b/HIP/protocol/hip-23/indexer_dictionary.md
@@ -1,0 +1,121 @@
+# HIP-23 Indexer Field Dictionary
+
+Version: 1.0 (HIP-23 v1.1)  
+Date: 2026-06-22  
+Audience: explorer, indexer, analytics engineers
+
+---
+
+## 1. Transaction-level fields
+
+| Field | Type | When set | Description |
+|-------|------|----------|-------------|
+| `hip23_pattern` | enum | classifier | `P1`…`P5` or `unknown` |
+| `istanbul_gated` | bool | always | `height >= 765432` on mainnet |
+| `gas_max` | u8 | Type3 | Gas budget |
+| `gas_used` | u8 | Type3 success | Consumed gas |
+| `fast_sync_bypass` | bool | dev only | True if node ran without sig checks |
+
+---
+
+## 2. Guard outcome fields
+
+| Field | Type | Values | Notes |
+|-------|------|--------|-------|
+| `guard_kind` | string | `HeightScope`, `BalanceFloor`, `ChainAllow` | From action type |
+| `guard_outcome` | enum | `pass`, `revert`, `fault` | Per guard execution |
+| `guard_error_norm` | string | see §3 | Normalized substring match |
+
+**Revert vs fault (MUST classify):**
+
+- **Revert:** expected predicate false (e.g. outside height window) — P2 fails whole tx; P5 may take else.
+- **Fault:** invalid parameters or protocol violation (e.g. `start > end`).
+
+---
+
+## 3. Normalized error strings (v1)
+
+Reference implementation: `[hip23-integration/tests/common/hip23_errors.rs](https://github.com/Moskyera/hip23-integration)` (`classify_error`, `error_code_name`).
+
+Indexers SHOULD map raw errors to these buckets:
+
+| Bucket | Substring(s) | `guard_outcome` |
+|--------|--------------|-----------------|
+| `height_outside_window` | `submitted in height between` | revert |
+| `height_invalid_range` | `start height cannot be greater` | fault |
+| `balance_below_floor` | `lower than floor` | revert |
+| `chain_not_allowed` | `chain id check failed` | revert |
+| `guard_only_topology` | `all GUARD` | fault (precheck) |
+| `tex_settlement_imbalance` | `settlement check failed` | fault |
+| `tex_sig_fail` | `signature verification failed` | fault |
+| `gas_not_initialized` | `gas not initialized` | fault |
+| `duplicate_tx` | `already exists` | fault |
+| `protocol_cost_mismatch` | `protocol cost` | fault |
+
+There is **no** stable on-chain enum in v1 — string matching is required.
+
+---
+
+## 4. TEX fields (P1, P4 Tx B)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tex_signer` | address | `TexCellAct.addr` |
+| `tex_cell_ids` | uint[] | Cell types in bundle |
+| `tex_zhu_delta` | map addr→i64 | Net zhu change at settlement |
+| `tex_sat_delta` | map addr→i64 | Net sat change |
+| `tex_dia_delta` | map addr→i32 | Net diamond count change |
+| `tex_asset_delta` | map (addr,serial)→i64 | Per-asset net change |
+| `tex_settlement_ok` | bool | `do_settlement()` succeeded |
+
+---
+
+## 5. P4 two-tx correlation
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `hip20_serial` | u64 | Asset serial |
+| `hip20_issuer` | address | From `AssetCreate.metadata.issuer` |
+| `hip20_tx_role` | enum | `issuance` (Tx A) or `distribution` (Tx B) |
+| `hip20_correlation_id` | string | `{serial}:{issuer}` or custom |
+| `hip20_same_block` | bool | Tx A and Tx B in same block |
+
+Indexers MUST NOT treat P4 as single atomic tx — store two linked events.
+
+---
+
+## 6. P5 AST fields
+
+| Field | Type | Values |
+|-------|------|--------|
+| `ast_branch` | enum | `if`, `else`, `none` |
+| `cond_outcome` | enum | `success`, `revert`, `fault` |
+| `ast_depth` | u8 | Max depth reached |
+| `ast_gas_used` | u8 | Gas consumed |
+
+**Important:** `cond_outcome=revert` + `ast_branch=else` + tx success is a **valid** outcome, not a failed tx.
+
+---
+
+## 7. P2 vs P5 classifier hints
+
+| Observation | Likely pattern |
+|-------------|----------------|
+| Top-level `HeightScope` + transfer, tx failed outside window | P2 |
+| `AstIf` + height cond, else transfer, tx succeeded outside window | P5 |
+| `ast_branch=else` present | P5 |
+
+---
+
+## 8. Example JSON (indexer output)
+
+```json
+{
+  "tx_hash": "0x…",
+  "hip23_pattern": "P5",
+  "ast_branch": "else",
+  "cond_outcome": "revert",
+  "guard_error_norm": "height_outside_window",
+  "tex_settlement_ok": true
+}
+```

--- a/HIP/protocol/hip-23/invariants.md
+++ b/HIP/protocol/hip-23/invariants.md
@@ -1,0 +1,104 @@
+# HIP-23 Protocol Invariants
+
+Version: 1.0  
+Date: 2026-06-22  
+Audience: auditors, protocol developers, QA  
+Model: `vm/doc/runtime-spec.md` §11, `doc/diamond-insc.md` §4.2
+
+---
+
+## 1. Global invariants (all patterns)
+
+| ID | Invariant | Enforcement |
+|----|-----------|-------------|
+| G-1 | Type3 txs with Istanbul actions use `type >= 3` | `check_gated_*` |
+| G-2 | Guard-only topologies rejected at precheck | `precheck_tx_actions` |
+| G-3 | `do_settlement()` runs after top-level actions on Type3 | `type3.rs` execute path |
+| G-4 | Failed tx execution does not commit partial state (chain path) | `chain/src/check.rs` fork/merge |
+| G-5 | Each `TexCellAct` signature covers `addr + cells` only | TEX sign/verify |
+| G-6 | Mainnet Istanbul height `>= 765432` unless dev bypass | `upgrade.rs` |
+
+---
+
+## 2. TEX settlement invariants (P1, P4 Tx B)
+
+| ID | Invariant | Violation symptom |
+|----|-----------|-------------------|
+| T-1 | Σ zhu pay = Σ zhu get per tx | `coin settlement check failed` |
+| T-2 | Σ sat pay = Σ sat get per tx | `coin settlement check failed` |
+| T-3 | Σ dia pay = Σ dia get per tx | `diamonds settlement check failed` |
+| T-4 | Σ asset(serial) pay = Σ asset(serial) get per tx | `asset <n> settlement check failed` |
+| T-5 | TEX cells execute before settlement | Ledger updated pre-`do_settlement()` |
+| T-6 | Asset TEX cells (`7/8`) require `gas_max > 0` | `gas not initialized` |
+
+**Zero-sum property (formal):** For each dimension `d ∈ {zhu, sat, dia, assets*}`,  
+`Σ debits_d = Σ credits_d` at settlement boundary.
+
+---
+
+## 3. Guard invariants (P2, P3, P5 cond)
+
+| ID | Invariant | Notes |
+|----|-----------|-------|
+| GU-1 | Guards observe state after all lower-index actions | Sequential action index |
+| GU-2 | `HeightScope` revert is inclusive `[start, end]` | `end=0` → unbounded above |
+| GU-3 | `HeightScope` invalid range (`start > end`, `end≠0`) → **fault** | Not revert |
+| GU-4 | `BalanceFloor` checks in-tx balance at guard position | Not pre-tx chain state |
+| GU-5 | Guard revert → action error unwind (tx fails for top-level guards) | P2 whole-tx fail |
+| GU-6 | P5 cond revert → `br_else`; cond fault → abort `AstIf` | See `doc/ast-spec.md` |
+
+---
+
+## 4. Pattern-specific invariants
+
+### P2
+
+- **P2-1:** `HeightScope` index < debit action index (MUST).
+- **P2-2:** Outside window → tx fails entirely (no partial commit on chain).
+
+### P3
+
+- **P3-1:** Debit index < `BalanceFloor` index (MUST).
+- **P3-2:** At least one floor field non-zero (MUST).
+- **P3-3:** Type3 fee debited after all actions — floor does not include fee unless modeled.
+
+### P4
+
+- **P4-1:** `AssetCreate` is sole top action in Tx A (`TOP_ONLY`).
+- **P4-2:** `protocol_cost == genesis::block_reward(height)` exactly.
+- **P4-3:** Asset serial ≥ minsri at height on mainnet.
+- **P4-4:** Tx B TEX only after asset exists in state (same block order or later).
+
+### P5
+
+- **P5-1:** `gas_max > 0` when AST depth > 0.
+- **P5-2:** Cond `AstSelect` uses `exe_min = exe_max = 1` for single predicates.
+- **P5-3:** Gas consumed on cond attempt is not refunded on revert.
+
+---
+
+## 5. Chain execution invariants
+
+| ID | Invariant | Test |
+|----|-----------|------|
+| C-1 | `try_execute_tx_by` forks from accumulated block state | `hip23_chain_*` |
+| C-2 | Success → `merge_sub`; failure → discard fork | `hip23_chain_failed_tx_does_not_commit` |
+| C-3 | Sequential successful txs compose (P4 A→B) | `hip23_chain_p4_tx_a_then_b_commits` |
+
+---
+
+## 6. Known non-invariants (documented exceptions)
+
+1. **TEX signatures are replayable** across txs with identical cells — not a bug; wallets must pin composed tx.
+2. **`fast_sync=true`** disables signature and duplicate-tx checks — test-only relaxation.
+3. **In-tx partial progress** visible in direct `tx.execute()` simulators — not chain-persistent on failure.
+
+---
+
+## 7. Regression proof
+
+Each invariant ID maps to tests in `requirements_traceability.md`. Run:
+
+```bash
+cargo test hip23_ -- --nocapture
+```

--- a/HIP/protocol/hip-23/requirements_traceability.md
+++ b/HIP/protocol/hip-23/requirements_traceability.md
@@ -1,0 +1,132 @@
+# HIP-23 Requirements Traceability Matrix
+
+Version: 1.0  
+Date: 2026-06-22  
+Legend: ✅ covered | ⚠️ doc-only | ❌ gap
+
+---
+
+## §3 Common requirements
+
+| ID | Requirement | Test(s) | Status |
+|----|-------------|---------|--------|
+| C-3.1 | Type >= 3 for Istanbul actions | implicit in all `build_signed_type3` tests | ✅ |
+| C-3.2 | gas_max > 0 for AST / asset TEX | `hip23_p1_tex_asset_cells_require_gas`, `hip23_p5_ast_requires_nonzero_gas` | ✅ |
+| C-3.3 | Mainnet height >= 765432 | `TEST_HEIGHT` baseline; stress @ alive height | ✅ |
+| C-3.4 | TEX zero-sum settlement | `hip23_p1_*`, proptest balanced/imbalanced | ✅ |
+| C-3.5 | TEX signs addr+cells | `hip23_p1_tex_tampered_signature_fails`, `hip23_tex_replay_*` | ✅ |
+| C-3.6 | No guard-only topology | `hip23_topology_guard_only_*`, proptest guard-only | ✅ |
+| C-3.7 | Asset TEX gas init | `hip23_p1_tex_asset_cells_require_gas`, stress low gas | ✅ |
+
+---
+
+## §4 P1 — TEX swap
+
+| ID | MUST/SHOULD | Test(s) | Status |
+|----|-------------|---------|--------|
+| P1-M1 | Matching pay/get cells | `hip23_pattern_1_*`, `hip23_production_p1_*` | ✅ |
+| P1-M2 | Zero-sum per dimension | `hip23_p1_tex_imbalanced_hac_amount_fails`, `hip23_p1_tex_imbalanced_sat_fails` | ✅ |
+| P1-M3 | Tamper after sign fails | `hip23_p1_tex_tampered_signature_fails`, `hip23_audit_strict_tex_tamper_rejected` | ✅ |
+| P1-S1 | Condition cells optional | `hip23_p1_tex_height_condition_in_bundle` | ✅ |
+| P1-S2 | HAC prelude + TEX | `hip23_p1_tex_with_hac_to_trs_prelude_succeeds` | ✅ |
+
+---
+
+## §5 P2 — Height guard
+
+| ID | MUST/SHOULD | Test(s) | Status |
+|----|-------------|---------|--------|
+| P2-M1 | HeightScope before debit | `hip23_pattern_2_height_guarded_payment` | ✅ |
+| P2-M4 | Chain atomicity on fail | `hip23_chain_failed_tx_does_not_commit`, `hip23_p2_transfer_before_guard_*` | ✅ |
+| P2-M2 | start <= end (end≠0) | adversarial height tests | ✅ |
+| P2-M3 | Revert outside window | `hip23_p2_height_guard_above_end_reverts`, proptest height window | ✅ |
+| P2-S1 | Finite end for expiry | `hip23_p2_height_guard_boundary_inclusive` | ✅ |
+
+
+---
+
+## §6 P3 — BalanceFloor
+
+| ID | MUST/SHOULD | Test(s) | Status |
+|----|-------------|---------|--------|
+| P3-M1 | Floor after debits | `hip23_pattern_3_*`, `hip23_p3_floor_before_transfer_*` | ✅ |
+| P3-M2 | Non-zero floor field | `hip23_p3_floor_asset_dimension_*`, satoshi dimension | ✅ |
+| P3-M3 | Revert below floor | `hip23_combined_height_floor_transfer_below_floor_fails` | ✅ |
+| P3-S1 | Model fee in floor | doc + wallet checklist | ⚠️ |
+| P3-S2 | Non-zero fields only | `hip23_p3_floor_before_transfer_*` | ✅ |
+
+---
+
+## §7 P4 — HIP20 + TEX
+
+| ID | MUST/SHOULD | Test(s) | Status |
+|----|-------------|---------|--------|
+| P4-M1 | AssetCreate TOP_ONLY | `hip23_p4_asset_create_with_tex_same_tx_rejected` | ✅ |
+| P4-M2 | TEX after asset exists | `hip23_pattern_4_*`, `hip23_chain_p4_tx_a_then_b_commits` | ✅ |
+| P4-M3 | gas_max > 0 on asset TEX | production P4, stress | ✅ |
+| P4-M4 | protocol_cost exact | `hip23_p4_wrong_protocol_cost_rejected`, `hip23_audit_strict_wrong_protocol_cost` | ✅ |
+| P4-M5 | Serial minsri | `hip23_stress_*` serial 1025, below minsri fault | ✅ |
+| P4-S1 | Pre-sign Tx B | wallet checklist | ⚠️ |
+
+---
+
+## §8 P5 — AST conditional
+
+| ID | MUST/SHOULD | Test(s) | Status |
+|----|-------------|---------|--------|
+| P5-M1 | gas_max > 0 | `hip23_p5_ast_requires_nonzero_gas` | ✅ |
+| P5-M2 | cond exe_min=max=1 | pattern 5 template default | ✅ |
+| P5-M3 | No guard-only AST topology | topology tests | ✅ |
+| P5-M4 | Revert→else, fault→abort | `hip23_p5_ast_if_condition_fault_*`, `hip23_p5_ast_else_branch_*` | ✅ |
+| P5-S1 | Guard-only cond | pattern 5 structure | ✅ |
+| P5-S2 | Simple branch actions | production P5 | ✅ |
+
+---
+
+## §9 Security considerations
+
+| Topic | Test(s) | Status |
+|-------|---------|--------|
+| TEX replay | `hip23_tex_replay_*` | ✅ |
+| Ordering | P2/P3 adversarial, chain | ✅ |
+| Co-signing | wallet checklist + tamper tests | ✅ |
+| Gas under-budget | stress low gas, P5 zero gas | ✅ |
+| P2 vs P5 | doc §5.6 + P5 else tests | ✅ |
+
+---
+
+## Production-path (strict mode)
+
+| Control | Test(s) | Status |
+|---------|---------|--------|
+| Signature verify | `hip23_production_tampered_main_signature_rejected`, `hip23_audit_strict_*` | ✅ |
+| Duplicate tx | `hip23_production_duplicate_tx_rejected` | ✅ |
+| P1–P5 smoke | `hip23_production_p1_*` … `p5_*` | ✅ |
+| Strict proptest | `hip23_proptest_strict_balanced_tex_settles` | ✅ |
+
+---
+
+## Coverage summary
+
+| Category | MUST items | Covered | % |
+|----------|------------|---------|---|
+| Common §3 | 7 | 7 | 100% |
+| P1 | 3 | 3 | 100% |
+| P2 | 4 | 4 | 100% |
+| P3 | 3 | 3 | 100% |
+| P4 | 5 | 5 | 100% |
+| P5 | 4 | 4 | 100% |
+| **Total MUST** | **26** | **26** | **100%** |
+
+SHOULD items: 8/10 tested (2 wallet-process items doc-only by design).
+
+---
+
+## Gaps / backlog
+
+| Gap | Planned |
+|-----|---------|
+| `cargo-fuzz` TEX parse | v1.2 |
+| P4/P5 dedicated proptest properties | R-04 |
+| Cross-implementation vectors | R-05 |
+| External audit sign-off | pre-mainnet wallet |

--- a/HIP/protocol/hip-23/spec.md
+++ b/HIP/protocol/hip-23/spec.md
@@ -1,0 +1,358 @@
+# HIP-23: Istanbul DeFi Application Patterns
+
+**Status:** v1.1 Ready  
+**Type:** Application / integration standard — **no consensus fork**  
+**Activation:** Istanbul capabilities @ mainnet height `765432` (`ONLINE_OPEN_HEIGHT`)  
+**Depends on:** Type3 transactions, ActionGuard, TEX, AST, HIP20 (`AssetCreate`), HVM (optional)
+
+## 1. Purpose
+
+HIP-23 documents **reusable DeFi composition patterns** on post-Istanbul Hacash. It does not introduce new protocol actions, fork heights, or consensus rules. Wallets, indexers, gateways, and integrators MAY implement these patterns today using existing Istanbul machinery.
+
+Goals:
+
+- Give builders copy-paste-safe transaction templates for common financial flows.
+- Tie each pattern to **normative MUST/SHOULD** rules wallets and indexers can validate off-chain.
+- Provide regression tests (`[hip23-integration/tests/hip23_pattern_regression.rs](https://github.com/Moskyera/hip23-integration)`) that lock pattern semantics to `fullnodedev`.
+
+Reference material:
+
+- Height gates and Istanbul action registry: `protocol/src/upgrade.rs`
+- TEX settlement: `protocol/src/tex/*`, `tests/tex.rs` (`trs1`)
+- AST control flow: `doc/ast-spec.md`
+- Guards: `protocol/src/action/chain.rs`
+- JSON templates: `templates.md`
+- Audit package: `threat_model.md`, `invariants.md`, `requirements_traceability.md`, `wallet_checklist.md`, `indexer_dictionary.md`, `audit_scope.md`, `audit_findings.md`, `external_audit_brief.md`
+- Error classifier: `[hip23-integration/tests/common/hip23_errors.rs](https://github.com/Moskyera/hip23-integration)`
+- Test vectors: `[hip23-integration/tests/fixtures/hip23_test_vectors.json](https://github.com/Moskyera/hip23-integration)`
+
+## 2. Scope
+
+### 2.1 In scope (v1)
+
+| ID | Pattern | Primary primitives |
+|----|---------|-------------------|
+| P1 | Atomic multi-asset TEX swap | `TexCellAct` (kind 22), transfer cells 1–8 |
+| P2 | Time-boxed guarded payment | `HeightScope` (0x0412) + top transfer |
+| P3 | BalanceFloor protected transfer | `BalanceFloor` (0x0413) + ordered debits |
+| P4 | HIP20 issuance + TEX distribution | `AssetCreate` (16) + asset TEX cells 7/8 |
+| P5 | AST conditional settlement | `AstIf` / `AstSelect` + `HeightScope` condition |
+
+### 2.2 Out of scope (v1)
+
+- New action kinds or fork gates
+- HVM contract templates (future HIP-23 v2 MAY add optional contract companions)
+- Cross-chain bridges, oracle networks, or mempool policy
+- Fee-market or MEV recommendations
+
+## 3. Common requirements
+
+All patterns MUST satisfy:
+
+1. **Transaction type:** Use `type >= 3` when submitting `TexCellAct`, AST nodes, or other Istanbul-gated actions that require Type3.
+2. **Gas budget:** Set `gas_max > 0` when AST depth > 0 or when asset TEX cells (`cellid` 7 or 8) are present. Plain HAC/SAT/diamond TEX without asset cells MAY use `gas_max = 0` (see P2).
+3. **Height gate:** On mainnet (`chain_id = 0`), Istanbul actions MUST only be submitted at `height >= 765432`, except dev/regtest windows documented in `protocol/src/upgrade.rs`. On non-mainnet chains (`chain_id != 0`), `check_gated_*` bypasses these gates — testnets MUST document their own policy.
+4. **TEX settlement:** Type3 execution always calls `do_settlement()` after top-level actions (`protocol/src/transaction/type3.rs`). If any TEX transfer cells ran, zhu/sat/dia/asset ledger totals MUST be zero-sum before settlement succeeds.
+5. **TEX signatures:** Each `TexCellAct` MUST be signed over `addr + cells` only (replayable across transactions).
+6. **Guard topology:** Bare `GUARD` actions MAY appear at top level alongside other top actions. Transactions MUST NOT be guard-only (`protocol/src/action/level.rs`).
+7. **Asset TEX gas:** Transactions with asset transfer TEX cells (`cellid` 7 or 8) MUST set `gas_max > 0` and initialize gas (`extra9` path).
+
+Wallets SHOULD:
+
+- Pre-validate TEX zero-sum pairing off-chain before co-signing counterparty bundles.
+- Before signing a TEX bundle, verify its cells appear in the **agreed composed Type3 transaction** (structural equality or tx hash), not only that signer `addr` matches.
+- Display guard windows (height, chain, balance floor) in human-readable form.
+- Reject co-signed TEX bundles whose `addr` does not match the expected counterparty.
+
+Indexers SHOULD:
+
+- Index `TexCellAct` by signer `addr` and settled asset/diamond deltas.
+- Classify guard outcomes as **Revert** vs **Fault** and store normalized error text (e.g. `"submitted in height between"`, `"lower than floor"`). There is no stable on-chain guard reason-code enum in v1.
+- Correlate issuance (Tx A) and TEX distribution (Tx B) by asset serial, issuer, and block position; index them as a coordinated two-tx event (same block or later), not a single-tx atomic mint+distribute.
+- For P5 AST txs, record `ast_branch: if|else` and `cond_outcome: success|revert|fault` on successful transactions (condition revert with else success is not a failed tx).
+
+## 4. Pattern P1 — Atomic multi-asset TEX swap
+
+### 4.1 Intent
+
+Two or more parties atomically exchange HAC, SAT, diamonds, and/or HIP20 assets in one transaction without trusting an escrow contract.
+
+### 4.2 Structure
+
+1. Party A publishes `TexCellAct_A` with pay cells (`cellid` 1/3/5/7) and/or get cells (`2/4/6/8`).
+2. Party B publishes `TexCellAct_B` with the mirrored get/pay cells.
+3. A coordinator (or either party) combines both signed bundles in one Type3 transaction.
+4. Optional funding actions (e.g. `HacToTrs`) MAY precede TEX actions in the same tx. `AssetCreate` is `TOP_ONLY` and MUST use the two-tx P4 flow (§7).
+
+### 4.3 Rules
+
+- MUST: For every pay cell in A, B MUST include the matching get cell (same asset serial, amount, coin type).
+- MUST: TEX ledger totals for `zhu`, `sat`, `dia`, and each asset serial MUST be zero before `do_settlement()`.
+- MUST: Each party signs only their own bundle; tampering after sign MUST fail verification.
+- SHOULD: Include TEX condition cells (`cellid >= 11`) when quoting requires balance/height proofs at execution time.
+
+### 4.4 Failure modes
+
+| Failure | Result |
+|---------|--------|
+| Imbalanced pay/get | Fault at settlement (`coin` / `asset <n>` / `diamonds settlement check failed`) |
+| Bad signature | Fault on `TexCellAct` execute |
+| Missing asset / insufficient balance | Fault during cell execute |
+| Asset cells without gas | Fault (`gas not initialized`) |
+
+## 5. Pattern P2 — Time-boxed guarded payment
+
+### 5.1 Intent
+
+Release a payment only if the transaction is included within a block-height window.
+
+### 5.2 Structure
+
+```
+actions: [
+  HeightScope { start, end },   // GUARD, top-level
+  HacToTrs | SatToTrs | ...     // non-guard debit
+]
+```
+
+`end = 0` means unlimited upper bound (per `HeightScope` semantics).
+
+### 5.3 Rules
+
+- MUST: List `HeightScope` **before** the debit action (lower action index runs first).
+- MUST: `start <= end` when `end != 0` (otherwise **fault**, not revert).
+- MUST: Revert (not fault) when current height is outside `[start, end]` (inclusive).
+- SHOULD: Set `end` to a finite deadline for offer expiry.
+
+### 5.4 Wallet pitfall (ordering)
+
+Actions run sequentially. If a debit is listed before `HeightScope` and the guard later
+reverts, the **transaction still fails**, but step-by-step simulators may already show the
+debit as executed. Wallets MUST NOT present partial action progress as final settlement.
+Always validate the full tx atomically (`hip23_p2_transfer_before_guard_still_reverts_outside_window`).
+
+On a full node, `try_execute_tx_by` forks state per transaction and merges only on success
+(`chain/src/check.rs`); failed txs do not commit partial mutations. Direct `tx.execute()`
+calls in tests or wallet simulators can still observe in-tx partial progress that would not
+persist on-chain.
+
+### 5.5 Wallet display
+
+Wallets SHOULD show: “Valid heights: `start` … `end` (inclusive)”.
+
+### 5.6 P2 vs P5
+
+| Aspect | P2 (top-level guard) | P5 (`AstIf` + guard condition) |
+|--------|----------------------|----------------------------------|
+| Guard revert outside window | **Whole tx fails** | **`br_else` runs**; tx may succeed |
+| Use when | Payment must not settle unless in window | Fallback branch or no-op else is desired |
+| Wallet display | “Expired — tx failed” | “Condition false — else branch taken” |
+
+## 6. Pattern P3 — BalanceFloor protected transfer
+
+### 6.1 Intent
+
+Prevent a transaction from leaving an address below a minimum HAC/SAT/diamond/asset balance.
+
+### 6.2 Structure
+
+```
+actions: [
+  <debit action>,               // e.g. HacToTrs
+  BalanceFloor { addr, ... }    // GUARD, checks in-tx state at this point
+]
+```
+
+`BalanceFloor` intentionally inspects **in-transaction state at the guard position**, not pre-tx chain state. Type3 **fee is debited after all actions** — floors do not see post-fee balances unless the integrator models fee in the floor value.
+
+### 6.3 Rules
+
+- MUST: Place `BalanceFloor` **after** debits that should be protected.
+- MUST: Specify at least one non-zero floor field (`hacash`, `satoshi`, `diamond`, or `assets`).
+- MUST: Revert when any checked dimension is below floor.
+- SHOULD: Floor values include expected post-transfer dust retention **and** tx `fee` (and gas-paid HAC if applicable) when minimum **final** on-chain balance is intended.
+- SHOULD: Only set non-zero fields for dimensions being protected; zero `hacash` does not guard HAC.
+
+### 6.4 Wallet pitfall (ordering)
+
+If `BalanceFloor` is listed **before** a debit, the guard reads **pre-debit** balances and protection is bypassed while the tx may still succeed (`hip23_p3_floor_before_transfer_checks_pre_debit_state`). Wallets MUST enforce debit-then-floor ordering for P3.
+
+Step-by-step simulators may show debits before a failing floor; the full tx still reverts atomically on-chain (see §5.4).
+
+## 7. Pattern P4 — HIP20 issuance + TEX distribution
+
+### 7.1 Intent
+
+Mint a HIP20 asset in Tx A, then distribute units to counterparties via TEX in Tx B (same block or later).
+
+### 7.2 Structure
+
+`AssetCreate` is `TOP_ONLY` — it MUST be the **sole** top-level action in Tx A (no guards, no TEX, no other actions).  
+Distribution therefore uses **two coordinated transactions**:
+
+```
+Tx A (issuance):
+  actions: [ AssetCreate { metadata, protocol_cost } ]
+
+Tx B (distribution, after Tx A confirms or in a later pass):
+  actions: [
+    TexCellAct_issuer  (AssetPay cells),
+    TexCellAct_counter (AssetGet cells),
+  ]
+```
+
+### 7.3 Rules
+
+- MUST: Keep `AssetCreate` alone at top level (`TOP_ONLY` topology).
+- MUST: Run TEX distribution only after the asset exists on-chain (same block ordering or later block).
+- MUST: `issuer` in metadata receives minted supply; issuer SHOULD sign issuer `AssetPay` TEX cells (protocol does not bind `TexCellAct.addr` to `metadata.issuer`).
+- MUST: Set `gas_max > 0` on Type3 txs with asset TEX cells.
+- MUST: Pay `protocol_cost` **exactly equal** to `genesis::block_reward(height)` at inclusion height; debited from **`tx.main`**, not `metadata.issuer`.
+- MUST: On mainnet, asset serial `>= 1025` at `ASSET_ALIVE_HEIGHT` (`765432`); serial ceiling grows with height (see `mint/src/action/asset.rs`).
+- SHOULD: Pre-sign TEX bundles for Tx B before broadcasting Tx A.
+
+## 8. Pattern P5 — AST conditional settlement
+
+### 8.1 Intent
+
+Choose between settlement branches based on an on-chain guard predicate without deploying a contract.
+
+### 8.2 Structure
+
+```
+actions: [
+  AstIf {
+    cond:   AstSelect { HeightScope | BalanceFloor | ... },
+    br_if:  AstSelect { HacToTrs | TexCellAct | ... },
+    br_else: AstSelect { ... }
+  }
+]
+```
+
+### 8.3 Rules
+
+- MUST: Use Type3 with `gas_max > 0` when AST depth > 0.
+- MUST: Condition `AstSelect` use `exe_min = exe_max = 1` for single guard predicates.
+- MUST: Guard-only `AstSelect` / `AstIf` nodes are invalid at tx topology precheck.
+- MUST: Condition guard `Revert` selects `br_else`; condition `Fault` aborts entire `AstIf`.
+- SHOULD: Condition `AstSelect` contain guard-only actions (no balance mutations in `cond`).
+- SHOULD: Keep branch actions simple (single transfer or TEX bundle) for wallet simulation.
+
+### 8.4 Wallet display
+
+- Show which branch executed: `if` vs `else`.
+- Distinguish **condition fault** (invalid range → whole tx fails) from **condition revert** (outside window → else branch).
+- Budget gas for **both** condition attempt and branch attempt; AST try costs are not refunded on revert (`doc/ast-spec.md` §6).
+
+### 8.5 Signatures and gas
+
+- `AstIf` collects signatures from `cond`, `br_if`, and `br_else` in the serialized tree — signers for **both** branches MAY be required at broadcast even if only one branch runs.
+- Minimum `gas_max` for simple HAC `br_if` + `HeightScope` cond: **17** (template default). TEX or VM branches need higher budgets.
+
+## 9. Security considerations
+
+- **TEX replay:** Signed TEX bundles are replayable; never treat a signature alone as a one-time authorization. Pin the full composed tx before co-signing.
+- **Ordering:** Guards only see state mutations from earlier actions in the same transaction.
+- **Co-signing:** Verify counterparty TEX cells match your quote before signing.
+- **Gas:** AST and asset TEX paths consume gas; under-budgeted txs fail after partial snapshot work.
+- **P2 vs P5:** Do not use P5 when a failed guard must abort the entire payment (use P2).
+
+## 10. Versioning
+
+| Version | Contents |
+|---------|----------|
+| v1.0 | Patterns P1–P5, JSON templates, regression + adversarial tests |
+| v1.1 (this draft) | Wallet checklist, indexer dictionary, threat model, invariants, traceability, audit package |
+| v2.0 (future) | Optional HVM companion contracts per pattern |
+
+## 11. Test matrix
+
+### Happy path (`hip23_pattern_regression.rs`)
+
+| Pattern | Test |
+|---------|------|
+| P1 | `hip23_pattern_1_atomic_tex_swap` |
+| P2 | `hip23_pattern_2_height_guarded_payment` |
+| P3 | `hip23_pattern_3_balance_floor_protected_transfer` |
+| P4 | `hip23_pattern_4_asset_create_plus_tex` |
+| P5 | `hip23_pattern_5_ast_conditional_settlement` |
+
+### Adversarial (`hip23_pattern_adversarial.rs`)
+
+| Area | Tests |
+|------|-------|
+| P1 TEX | imbalanced HAC/SAT, tampered sign, insufficient balance, gas required, HAC+SAT swap, height condition cell, HAC prelude + TEX |
+| P2 Guard | boundary inclusive, above-end reject, unlimited end, ChainAllow, wrong debit/guard order |
+| P3 Floor | asset dimension, satoshi dimension, pre-debit vs post-debit placement |
+| P4 HIP20 | duplicate serial, missing asset, issuer insufficient, wrong protocol_cost, `AssetCreate`+TEX same-tx rejected |
+| P5 AST | condition fault, else-branch transfer, zero gas rejected |
+| Topology | guard-only rejected (precheck + execute), height+floor+transfer combo (pass + fail), height+TEX combo (pass + fail) |
+
+### Stress (`hip23_pattern_stress.rs`)
+
+| Area | Tests |
+|------|-------|
+| Guards | triple ChainAllow+Height+Floor, height 0..0, far-future start |
+| TEX | three-party zero-sum, serial mismatch, empty/unsigned bundles, duplicate addr |
+| P3/P4/P5 | multi-debit floor, minsri serial + chained TEX, BalanceFloor AST cond, low gas |
+| HIP20 | serial 1025 @ alive height, serial below minsri fault |
+
+### Production path (`hip23_production_path.rs`)
+
+Smoke tests with `fast_sync = false` (`make_ctx_strict` in `[hip23-integration/tests/common/hip23.rs](https://github.com/Moskyera/hip23-integration)`):
+
+| Area | Tests |
+|------|-------|
+| P1–P5 happy path | `hip23_production_p1_tex_swap_succeeds` … `hip23_production_p5_ast_conditional_settlement` |
+| Mempool policy | `hip23_production_duplicate_tx_rejected`, `hip23_production_tampered_main_signature_rejected` |
+
+### Property-based (`hip23_proptest.rs`)
+
+| Property | Cases | Harness |
+|----------|-------|---------|
+| Balanced HAC TEX settles | 64 | `fast_sync = true` |
+| HeightScope `end=0` unbounded above | 64 | `fast_sync = true` |
+| HeightScope window (inside ok, outside fail) | 64 | `fast_sync = true` |
+| Guard-only always rejected at precheck | 64 | n/a |
+| Imbalanced TEX always fails | 64 | `fast_sync = true` |
+| Balanced TEX under strict path | 64 | `fast_sync = false` |
+| Wrong `protocol_cost` always fails (P4) | 64 | `fast_sync = true` |
+| P5 else on height revert | 64 | `fast_sync = true` |
+| TEX wire parse never panics | 64 | fuzz-adjacent |
+
+### Guard error codes (`hip23_guard_error_codes.rs`)
+
+Stable string → code mapping for indexers (F-007 mitigation).
+
+### Test vectors (`hip23_test_vectors.rs` + `[hip23-integration/tests/fixtures/hip23_test_vectors.json](https://github.com/Moskyera/hip23-integration)`)
+
+Cross-implementation acceptance registry (12+ vectors).
+
+### Audit strict (`hip23_audit_strict.rs`)
+
+Adversarial cases under `fast_sync = false`: imbalanced TEX, tampered TEX sig, height guard, wrong `protocol_cost`, main sig tamper, guard-only precheck.
+
+### Chain integration (`hip23_chain_integration.rs`)
+
+Per-tx fork/merge semantics (`chain/src/check.rs`): failed tx rollback, P4 Tx A→B sequencing, fail-then-success isolation.
+
+### TEX replay (`hip23_tex_replay.rs`)
+
+TEX signature scope: replay across different `main`, tamper after sign, extra unbalanced party.
+
+Run all:
+
+```bash
+cargo test hip23_ -- --nocapture
+```
+
+Run production + proptest only:
+
+```bash
+cargo test hip23_pro -- --nocapture
+```
+
+**Note:** Regression, adversarial, and stress suites use `fast_sync = true` to focus on pattern
+semantics (guards, TEX settlement, topology). Production-path and strict proptest suites use
+`fast_sync = false` to exercise signature verification and duplicate-tx rejection. Integrators
+should run both before shipping wallet or indexer integrations.

--- a/HIP/protocol/hip-23/templates.md
+++ b/HIP/protocol/hip-23/templates.md
@@ -1,0 +1,473 @@
+# HIP-23 JSON Templates (Type3)
+
+Templates for wallet builders and integrators. Replace placeholders in `ALL_CAPS`.  
+Action JSON uses `kind` (not `type`). TEX cells use `cellid` (not `kind`).
+
+**Normative rules:** `spec.md` (sections linked per pattern below).
+
+**Mainnet:** submit only at `height >= 765432` unless using dev/regtest gates.
+
+---
+
+## Shared placeholders
+
+| Token | Meaning |
+|-------|---------|
+| `MAIN_ADDR` | Transaction fee payer / primary signer |
+| `PARTY_A` / `PARTY_B` | TEX co-signers |
+| `RECIPIENT` | Payment destination |
+| `SERIAL` | HIP20 asset serial (u64); mainnet ≥ 1025 @ height 765432 |
+| `FEE` | Wire amount string, e.g. `"8:244"` |
+| `GAS_MAX` | Type3 gas byte: `0` for HAC-only TEX; `17+` for AST; `99` when asset TEX (cells 7/8) |
+| `TIMESTAMP` | Unix seconds |
+| `START_HEIGHT` / `END_HEIGHT` | Block height guard window (inclusive) |
+
+---
+
+## P1 — Atomic multi-asset TEX swap
+
+See `spec.md` §4.
+
+### Transfer cell reference (cells 1–8)
+
+| cellid | Role | Asset |
+|--------|------|-------|
+| 1 | ZhuPay | HAC zhu out |
+| 2 | ZhuGet | HAC zhu in |
+| 3 | SatPay | SAT out |
+| 4 | SatGet | SAT in |
+| 5 | DiaPay | Named diamonds out |
+| 6 | DiaGet | Diamond count in |
+| 7 | AssetPay | HIP20 out |
+| 8 | AssetGet | HIP20 in |
+
+Counterparty MUST mirror pay↔get with matching amounts/serials.
+
+### Minimal HAC + HIP20 swap (two parties)
+
+```json
+{
+  "type": 3,
+  "main": "MAIN_ADDR",
+  "fee": "FEE",
+  "gas_max": 99,
+  "timestamp": TIMESTAMP,
+  "actions": [
+    {
+      "kind": 22,
+      "addr": "PARTY_A",
+      "cells": [
+        { "cellid": 1, "haczhu": 100000000 },
+        { "cellid": 8, "serial": SERIAL, "amount": 50 }
+      ],
+      "sign": "PARTY_A_TEX_SIGN"
+    },
+    {
+      "kind": 22,
+      "addr": "PARTY_B",
+      "cells": [
+        { "cellid": 2, "haczhu": 100000000 },
+        { "cellid": 7, "serial": SERIAL, "amount": 50 }
+      ],
+      "sign": "PARTY_B_TEX_SIGN"
+    }
+  ]
+}
+```
+
+**Notes:** `gas_max: 99` required because cells 7/8 are present. HAC-only swaps MAY use `gas_max: 0`.
+
+### Party A bundle (HAC + SAT + diamonds + asset) — mirror for Party B
+
+Single-party TEX bundle; counterparty MUST use matching get/pay cells (see `tests/tex.rs` `trs1()`).
+
+```json
+{
+  "kind": 22,
+  "addr": "PARTY_A_BUYER",
+  "cells": [
+    { "cellid": 2, "haczhu": 100000000 },
+    { "cellid": 4, "satnum": 2 },
+    { "cellid": 6, "dianum": 3 },
+    { "cellid": 8, "serial": SERIAL, "amount": 100 }
+  ],
+  "sign": "PARTY_A_TEX_SIGN"
+}
+```
+
+```json
+{
+  "kind": 22,
+  "addr": "PARTY_B_SELLER",
+  "cells": [
+    { "cellid": 1, "haczhu": 100000000 },
+    { "cellid": 3, "satnum": 2 },
+    { "cellid": 5, "diamonds": "KKKKVA,HYXYHY,UETWNK" },
+    { "cellid": 7, "serial": SERIAL, "amount": 100 }
+  ],
+  "sign": "PARTY_B_TEX_SIGN"
+}
+```
+
+### Optional HAC funding before TEX
+
+```json
+{
+  "type": 3,
+  "main": "MAIN_ADDR",
+  "fee": "FEE",
+  "gas_max": 0,
+  "timestamp": TIMESTAMP,
+  "actions": [
+    { "kind": 1, "to": "PARTY_A", "hacash": "10:244" },
+    {
+      "kind": 22,
+      "addr": "PARTY_A",
+      "cells": [{ "cellid": 1, "haczhu": 100000000 }],
+      "sign": "PARTY_A_TEX_SIGN"
+    },
+    {
+      "kind": 22,
+      "addr": "PARTY_B",
+      "cells": [{ "cellid": 2, "haczhu": 100000000 }],
+      "sign": "PARTY_B_TEX_SIGN"
+    }
+  ]
+}
+```
+
+---
+
+## P2 — Time-boxed guarded payment
+
+See `spec.md` §5.
+
+```json
+{
+  "type": 3,
+  "main": "MAIN_ADDR",
+  "fee": "FEE",
+  "gas_max": 0,
+  "timestamp": TIMESTAMP,
+  "actions": [
+    {
+      "kind": 1042,
+      "start": START_HEIGHT,
+      "end": END_HEIGHT
+    },
+    {
+      "kind": 1,
+      "to": "RECIPIENT",
+      "hacash": "10:244"
+    }
+  ]
+}
+```
+
+**Notes:**
+
+- `kind` `1042` = `HeightScope` (`0x0412`).
+- Guard MUST be listed **before** the debit action.
+- `end: 0` = no upper height limit.
+- `start > end` (when `end != 0`) is a **fault**, not a revert.
+
+### ChainAllow variant
+
+```json
+{
+  "type": 3,
+  "main": "MAIN_ADDR",
+  "fee": "FEE",
+  "gas_max": 0,
+  "timestamp": TIMESTAMP,
+  "actions": [
+    { "kind": 1041, "chains": [0, 1] },
+    { "kind": 1, "to": "RECIPIENT", "hacash": "3:244" }
+  ]
+}
+```
+
+`kind` `1041` = `ChainAllow` (`0x0411`).
+
+---
+
+## P3 — BalanceFloor protected transfer
+
+See `spec.md` §6.
+
+```json
+{
+  "type": 3,
+  "main": "MAIN_ADDR",
+  "fee": "FEE",
+  "gas_max": 0,
+  "timestamp": TIMESTAMP,
+  "actions": [
+    {
+      "kind": 1,
+      "to": "RECIPIENT",
+      "hacash": "100:244"
+    },
+    {
+      "kind": 1043,
+      "addr": "MAIN_ADDR",
+      "hacash": "900:244",
+      "satoshi": 0,
+      "diamond": 0,
+      "assets": []
+    }
+  ]
+}
+```
+
+**Notes:**
+
+- `kind` `1043` = `BalanceFloor` (`0x0413`).
+- Floor is evaluated **after** the preceding debit.
+- Include tx `fee` in floor when protecting **final** post-settlement balance.
+- Add `assets: [{ "serial": SERIAL, "amount": MIN_AMT }]` to protect HIP20 balances.
+
+### Multi-debit then floor
+
+```json
+{
+  "actions": [
+    { "kind": 1, "to": "RECIPIENT_A", "hacash": "40:244" },
+    { "kind": 1, "to": "RECIPIENT_B", "hacash": "10:244" },
+    {
+      "kind": 1043,
+      "addr": "MAIN_ADDR",
+      "hacash": "900:244",
+      "satoshi": 0,
+      "diamond": 0,
+      "assets": []
+    }
+  ]
+}
+```
+
+---
+
+## P4 — HIP20 issuance + TEX distribution
+
+See `spec.md` §7.
+
+`AssetCreate` is `TOP_ONLY`. Use **two transactions**:
+
+### Tx A — issuance
+
+```json
+{
+  "type": 3,
+  "main": "MAIN_ADDR",
+  "fee": "FEE",
+  "gas_max": 0,
+  "timestamp": TIMESTAMP,
+  "actions": [
+    {
+      "kind": 16,
+      "metadata": {
+        "serial": SERIAL,
+        "supply": 10000,
+        "decimal": 2,
+        "issuer": "ISSUER_ADDR",
+        "ticket": "USDT",
+        "name": "Tether"
+      },
+      "protocol_cost": "BLOCK_REWARD_AT_HEIGHT"
+    }
+  ]
+}
+```
+
+**Notes:**
+
+- Tx A MUST contain **only** `AssetCreate` (no guards, no TEX).
+- `protocol_cost` MUST equal `genesis::block_reward(height)` at inclusion height (not a fixed literal).
+- `MAIN_ADDR` pays `protocol_cost`; `issuer` receives minted supply.
+
+### Tx B — TEX distribution (after Tx A is valid on-chain)
+
+```json
+{
+  "type": 3,
+  "main": "MAIN_ADDR",
+  "fee": "FEE",
+  "gas_max": 99,
+  "timestamp": TIMESTAMP,
+  "actions": [
+    {
+      "kind": 22,
+      "addr": "ISSUER_ADDR",
+      "cells": [
+        { "cellid": 7, "serial": SERIAL, "amount": 500 }
+      ],
+      "sign": "ISSUER_TEX_SIGN"
+    },
+    {
+      "kind": 22,
+      "addr": "RECIPIENT",
+      "cells": [
+        { "cellid": 8, "serial": SERIAL, "amount": 500 }
+      ],
+      "sign": "RECIPIENT_TEX_SIGN"
+    }
+  ]
+}
+```
+
+---
+
+## P5 — AST conditional settlement
+
+See `spec.md` §8.
+
+Pay only if height guard passes; otherwise fallback else branch:
+
+```json
+{
+  "type": 3,
+  "main": "MAIN_ADDR",
+  "fee": "FEE",
+  "gas_max": 17,
+  "timestamp": TIMESTAMP,
+  "actions": [
+    {
+      "kind": 26,
+      "cond": {
+        "kind": 25,
+        "exe_min": 1,
+        "exe_max": 1,
+        "actions": [
+          { "kind": 1042, "start": START_HEIGHT, "end": END_HEIGHT }
+        ]
+      },
+      "br_if": {
+        "kind": 25,
+        "exe_min": 1,
+        "exe_max": 1,
+        "actions": [
+          { "kind": 1, "to": "RECIPIENT", "hacash": "5:244" }
+        ]
+      },
+      "br_else": {
+        "kind": 25,
+        "exe_min": 1,
+        "exe_max": 1,
+        "actions": [
+          { "kind": 1, "to": "RECIPIENT", "hacash": "3:244" }
+        ]
+      }
+    }
+  ]
+}
+```
+
+**Notes:**
+
+- `kind` `26` = `AstIf`, `25` = `AstSelect`.
+- Condition guard failure (revert) selects `br_else`; invalid range (`start > end`) **faults** whole node.
+- `gas_max` MUST be non-zero for AST execution.
+- Signatures are collected from **all** branches in the serialized tree, not only the executed branch.
+- Empty else (`exe_min: 0, exe_max: 0, actions: []`) is equivalent to `AstSelect::nop()` in tests.
+
+---
+
+## Composition templates
+
+See `spec.md` §11 topology tests.
+
+### Height + BalanceFloor + transfer (happy path)
+
+```json
+{
+  "type": 3,
+  "main": "MAIN_ADDR",
+  "fee": "FEE",
+  "gas_max": 0,
+  "timestamp": TIMESTAMP,
+  "actions": [
+    { "kind": 1042, "start": START_HEIGHT, "end": END_HEIGHT },
+    { "kind": 1, "to": "RECIPIENT", "hacash": "40:244" },
+    {
+      "kind": 1043,
+      "addr": "MAIN_ADDR",
+      "hacash": "900:244",
+      "satoshi": 0,
+      "diamond": 0,
+      "assets": []
+    }
+  ]
+}
+```
+
+### Height guard + TEX swap
+
+```json
+{
+  "type": 3,
+  "main": "MAIN_ADDR",
+  "fee": "FEE",
+  "gas_max": 0,
+  "timestamp": TIMESTAMP,
+  "actions": [
+    { "kind": 1042, "start": START_HEIGHT, "end": END_HEIGHT },
+    {
+      "kind": 22,
+      "addr": "PARTY_A",
+      "cells": [{ "cellid": 1, "haczhu": 100000000 }],
+      "sign": "PARTY_A_TEX_SIGN"
+    },
+    {
+      "kind": 22,
+      "addr": "PARTY_B",
+      "cells": [{ "cellid": 2, "haczhu": 100000000 }],
+      "sign": "PARTY_B_TEX_SIGN"
+    }
+  ]
+}
+```
+
+---
+
+## Guard kind reference
+
+| kind (decimal) | kind (hex) | Action |
+|----------------|------------|--------|
+| 1041 | 0x0411 | `ChainAllow` |
+| 1042 | 0x0412 | `HeightScope` |
+| 1043 | 0x0413 | `BalanceFloor` |
+
+---
+
+## TEX condition cell reference (optional)
+
+| cellid | Name | Purpose |
+|--------|------|---------|
+| 11–13 | Zhu at most / at least / eq | HAC balance conditions |
+| 14–16 | Sat conditions | SAT balance conditions |
+| 17–19 | Diamond conditions | HACD count conditions |
+| 20–22 | Asset conditions | HIP20 balance conditions |
+| 23–24 | Height at most / at least | Block height conditions |
+| 25 | ChainId eq | Chain ID condition |
+
+Example height condition inside a TEX bundle:
+
+```json
+{ "cellid": 23, "height": 800000 }
+```
+
+---
+
+## Action kind quick reference
+
+| kind | Action |
+|------|--------|
+| 1 | `HacToTrs` |
+| 16 | `AssetCreate` |
+| 22 | `TexCellAct` |
+| 25 | `AstSelect` |
+| 26 | `AstIf` |
+| 1041 | `ChainAllow` |
+| 1042 | `HeightScope` |
+| 1043 | `BalanceFloor` |

--- a/HIP/protocol/hip-23/threat_model.md
+++ b/HIP/protocol/hip-23/threat_model.md
@@ -1,0 +1,143 @@
+# HIP-23 Threat Model
+
+Version: 1.0  
+Date: 2026-06-22  
+Audience: security reviewers, wallet/indexer engineers, integrators  
+Baseline: `spec.md` v1.1 draft
+
+---
+
+## 1. Scope
+
+This document models threats to **integrators** building on HIP-23 patterns P1–P5. It does not change consensus rules. Assumptions:
+
+- Istanbul is active (`height >= 765432` on mainnet).
+- Full nodes run with `fast_sync = false` in production (signature + duplicate-tx checks enabled).
+- HVM companion contracts are out of scope (HIP-23 v1).
+
+---
+
+## 2. Assets & trust boundaries
+
+| Asset | Owner | Threat if lost |
+|-------|-------|----------------|
+| Private keys (main, TEX signers) | User / counterparty | Direct fund loss |
+| Signed TEX bundles | Counterparty | Replay in unintended composed tx |
+| Composed Type3 tx draft | Coordinator | Wrong pairing, ordering, gas |
+| Indexer classification | Service operator | Wrong UX, compliance, accounting |
+| Block inclusion timing | Miner / network | Height-guard expiry (P2) |
+
+**Trust boundaries:**
+
+```
+Wallet A  <--co-sign TEX-->  Wallet B
+     |                              |
+     v                              v
+Coordinator (optional) ----> Full node (consensus)
+     |
+     v
+Indexer / explorer (read-only, MUST NOT authorize spends)
+```
+
+Users MUST NOT trust indexers or coordinators for authorization — only validated composed txs and signatures.
+
+---
+
+## 3. STRIDE analysis
+
+| Category | Threat | Patterns | Mitigation |
+|----------|--------|----------|------------|
+| **Spoofing** | Counterparty TEX `addr` mismatch | P1, P4 | Wallet verifies `TexCellAct.addr` before co-sign |
+| **Tampering** | Cells altered after TEX sign | P1, P4 | Signature over `addr+cells`; strict-path tests |
+| **Tampering** | Main Type3 signature tamper | All | `fast_sync=false` rejects (`hip23_production_tampered_main_signature_rejected`) |
+| **Repudiation** | “I didn’t agree to this swap” | P1 | Pin full composed tx hash before co-sign; store quote |
+| **Information disclosure** | Leaked co-sign bundle | P1 | Bundle alone cannot move funds without inclusion in valid tx |
+| **Denial of service** | Under-gassed AST/TEX | P4, P5 | Pre-validate `gas_max`; show gas estimate |
+| **Denial of service** | Height window miss | P2 | Show inclusive `[start,end]`; simulate at tip |
+| **Elevation** | Guard-only tx topology | P2, P3 | Precheck rejects (`hip23_topology_guard_only_*`) |
+| **Elevation** | `AssetCreate` + TEX same tx | P4 | `TOP_ONLY` rejected (`hip23_p4_asset_create_with_tex_same_tx_rejected`) |
+
+---
+
+## 4. Pattern-specific threats
+
+### P1 — Atomic TEX swap
+
+| ID | Threat | Severity | On-chain result | Off-chain MUST |
+|----|--------|----------|-----------------|----------------|
+| T-P1-1 | Imbalanced pay/get | High | Settlement fault | Zero-sum precheck |
+| T-P1-2 | TEX replay in different composed tx | Medium | Both txs may settle if funded | Pin full tx hash |
+| T-P1-3 | Post-sign cell tamper | High | Sig verify fail | Re-verify before broadcast |
+| T-P1-4 | Asset cells without gas | Medium | `gas not initialized` | `gas_max > 0` |
+
+### P2 — Height-guarded payment
+
+| ID | Threat | Severity | On-chain result | Off-chain MUST |
+|----|--------|----------|-----------------|----------------|
+| T-P2-1 | Debit before guard (simulator confusion) | Medium | Whole tx reverts | Atomic simulation |
+| T-P2-2 | Inclusive boundary off-by-one | Low | Revert outside window | Test `start` and `end` |
+| T-P2-3 | Using P5 when P2 semantics needed | Medium | Else branch pays | Pattern selection review |
+
+### P3 — BalanceFloor
+
+| ID | Threat | Severity | On-chain result | Off-chain MUST |
+|----|--------|----------|-----------------|----------------|
+| T-P3-1 | Floor before debit | High | Protection bypassed | Enforce debit→floor order |
+| T-P3-2 | Floor ignores post-fee balance | Medium | Floor passes, fee drains later | Model fee in floor value |
+| T-P3-3 | Zero dimension not guarded | Low | Unprotected asset/HAC | Set non-zero fields |
+
+### P4 — HIP20 + TEX
+
+| ID | Threat | Severity | On-chain result | Off-chain MUST |
+|----|--------|----------|-----------------|----------------|
+| T-P4-1 | TEX before asset exists | High | Fault | Tx B after Tx A |
+| T-P4-2 | Wrong `protocol_cost` | High | Fault | Quote `block_reward(height)` |
+| T-P4-3 | Issuer not signing pay cells | Medium | Settlement fail | Issuer co-sign |
+| T-P4-4 | Serial below minsri | High | Fault | Height-aware serial |
+
+### P5 — AST conditional
+
+| ID | Threat | Severity | On-chain result | Off-chain MUST |
+|----|--------|----------|-----------------|----------------|
+| T-P5-1 | Condition fault vs revert confusion | Medium | Abort vs else | UX labels (`cond_outcome`) |
+| T-P5-2 | Zero gas | Medium | Fault | `gas_max > 0` |
+| T-P5-3 | Signatures for both branches required | Low | Broadcast fail | Collect all branch signers |
+
+---
+
+## 5. Attacker profiles
+
+| Profile | Capability | Primary risk |
+|---------|------------|--------------|
+| Malicious counterparty | Co-signs TEX, changes composed tx | T-P1-2, T-P1-3 |
+| Malicious coordinator | Builds final Type3 | Ordering, extra actions |
+| Network observer | Read mempool | Front-running N/A for atomic TEX in same tx |
+| Rogue indexer | Wrong labels | Accounting / compliance |
+| Miner | Censor or delay | P2 expiry |
+
+---
+
+## 6. Residual risks (accepted in v1)
+
+1. **TEX replay:** Signatures are not bound to a specific composed tx hash — wallets MUST pin full tx (see `tests/hip23_tex_replay.rs`).
+2. **`fast_sync` test harness:** Most HIP-23 tests skip sig/duplicate checks; production-path suite required before release.
+3. **No stable guard reason codes:** Indexers parse error strings (see `HIP23_indexer_dictionary.md`).
+4. **P4 non-atomic:** Issuance and distribution are two txs — integrators MUST handle partial completion.
+
+---
+
+## 7. Verification mapping
+
+| Control | Test suite |
+|---------|------------|
+| Pattern semantics | `hip23_pattern_{regression,adversarial,stress}.rs` |
+| Production policy | `hip23_production_path.rs`, `hip23_audit_strict.rs` |
+| Chain atomicity | `hip23_chain_integration.rs` |
+| TEX replay awareness | `hip23_tex_replay.rs` |
+| Generative properties | `hip23_proptest.rs` |
+
+Run before release:
+
+```bash
+cargo test hip23_ -- --nocapture
+```

--- a/HIP/protocol/hip-23/wallet_checklist.md
+++ b/HIP/protocol/hip-23/wallet_checklist.md
@@ -1,0 +1,96 @@
+# HIP-23 Wallet Integration Checklist
+
+Version: 1.0 (HIP-23 v1.1)  
+Date: 2026-06-22  
+Use: pre-sign validation before broadcast or co-sign
+
+---
+
+## 0. Universal (all patterns)
+
+- [ ] Transaction `type >= 3`
+- [ ] Mainnet `height >= 765432` (or documented testnet policy)
+- [ ] `gas_max > 0` if AST depth > 0 **or** asset TEX cells (7/8) present
+- [ ] Not guard-only topology (at least one non-guard top action)
+- [ ] Simulate **full tx atomically** — do not show per-action finality on failure
+- [ ] Collect all required signatures (`req_sign` / branch signers for P5)
+- [ ] Fee payer (`tx.main`) has balance for `fee` + debits + gas
+
+---
+
+## P1 — Atomic TEX swap
+
+- [ ] Every pay cell in party A has matching get in party B (type, serial, amount)
+- [ ] Off-chain zero-sum check per dimension (zhu, sat, dia, each asset serial)
+- [ ] Each `TexCellAct.addr` matches expected counterparty address
+- [ ] Counterparty bundle verified **inside agreed composed Type3** (hash or structural equality)
+- [ ] No post-quote tampering of cells (re-verify signatures)
+- [ ] Fund pay-side balances before broadcast
+- [ ] If asset cells present: `gas_max > 0`
+
+---
+
+## P2 — Height-guarded payment
+
+- [ ] `HeightScope` listed **before** debit action
+- [ ] `start <= end` when `end != 0`
+- [ ] Display: “Valid heights: `start`…`end` (inclusive)”
+- [ ] Confirm P2 (not P5) if expiry must abort entire payment
+- [ ] `gas_max = 0` allowed for plain HAC transfer without asset TEX
+
+---
+
+## P3 — BalanceFloor protected transfer
+
+- [ ] Debit action(s) listed **before** `BalanceFloor`
+- [ ] At least one non-zero floor field for dimensions being protected
+- [ ] Floor value accounts for intended post-tx balance **and** `fee` (and gas if applicable)
+- [ ] Zero `hacash` floor does not protect HAC — set explicit fields only
+
+---
+
+## P4 — HIP20 issuance + TEX distribution
+
+- [ ] **Tx A:** `AssetCreate` is the **only** top-level action
+- [ ] `protocol_cost == block_reward(expected_height)` exactly
+- [ ] `tx.main` holds `protocol_cost` + `fee`
+- [ ] Asset serial ≥ minsri at target height (mainnet)
+- [ ] **Tx B:** only after Tx A confirmed (or same-block later ordering)
+- [ ] Issuer signs issuer `AssetPay` TEX cells
+- [ ] `gas_max > 0` on Tx B
+- [ ] Pre-sign Tx B bundles before broadcasting Tx A (recommended)
+
+---
+
+## P5 — AST conditional settlement
+
+- [ ] `gas_max > 0` (minimum 17 for simple HeightScope + HAC branch)
+- [ ] Cond `AstSelect`: `exe_min = exe_max = 1`
+- [ ] Cond contains guard-only actions (no debits in cond)
+- [ ] UX: distinguish condition **fault** (tx fails) vs **revert** (else runs)
+- [ ] Signatures collected for both branches if required by `req_sign`
+- [ ] Budget gas for cond + selected branch attempt
+
+---
+
+## Co-signing workflow (P1 / P4 Tx B)
+
+1. Agree on full action list, order, `fee`, `gas_max`, `main`.
+2. Hash composed unsigned tx (or canonical serialization).
+3. Each party signs TEX over agreed cells only after step 1–2 locked.
+4. Coordinator assembles; each party re-validates final wire tx before broadcast.
+
+---
+
+## Pre-broadcast simulation modes
+
+| Mode | Checks |
+|------|--------|
+| Fast preview | Pattern semantics only (`fast_sync` equivalent) |
+| Production | Signatures, duplicate-tx, fee rules (`fast_sync=false`) |
+
+Run repo tests before shipping wallet integration:
+
+```bash
+cargo test hip23_ -- --nocapture
+```


### PR DESCRIPTION
## Summary

Adds **HIP-23** documentation to \hacash/doc\ per maintainer guidance ([@jojoin on fullnodedev#8](https://github.com/hacash/fullnodedev/pull/8#issuecomment-4775960890)): one topic per file, no scattered docs in the dev repo.

**No consensus fork** — application/integration standard for post-Istanbul DeFi patterns (P1–P5).

## Location

\HIP/protocol/hip-23/\

| File | Topic |
|------|-------|
| spec.md | Normative patterns + MUST/SHOULD |
| templates.md | JSON transaction templates |
| threat_model.md, invariants.md, requirements_traceability.md | Audit package |
| wallet_checklist.md, indexer_dictionary.md | Integrator guides |
| audit_scope.md, audit_findings.md, external_audit_brief.md | Audit process |

Index: \HIP/protocol/hip-23/README.md\

## Integration tests

Comprehensive tests live in a separate repo (not fullnodedev):

https://github.com/Moskyera/hip23-integration

## HIP table

Added HIP-23 row to \HIP/HIP-table.md\ (status: in discussion).